### PR TITLE
fix: add font-features for all typography elements

### DIFF
--- a/blocks/big-text/big-text.css
+++ b/blocks/big-text/big-text.css
@@ -1,5 +1,6 @@
 .big-text {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 20px;
   font-weight: 700;
   line-height: 1.2;

--- a/blocks/heading1/heading1.css
+++ b/blocks/heading1/heading1.css
@@ -1,5 +1,6 @@
 .heading1 {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 72px;
   font-weight: 700;
   line-height: 1.2;

--- a/blocks/heading2/heading2.css
+++ b/blocks/heading2/heading2.css
@@ -1,5 +1,6 @@
 .heading2 {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 64px;
   font-weight: 700;
   line-height: 1.2;

--- a/blocks/heading3/heading3.css
+++ b/blocks/heading3/heading3.css
@@ -1,5 +1,6 @@
 .heading3 {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 36px;
   font-weight: 700;
   line-height: 1.2;

--- a/blocks/heading4/heading4.css
+++ b/blocks/heading4/heading4.css
@@ -1,5 +1,6 @@
 .heading4 {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 34px;
   font-weight: 700;
   line-height: 1.2;

--- a/blocks/heading5/heading5.css
+++ b/blocks/heading5/heading5.css
@@ -1,5 +1,6 @@
 .heading5 {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 24px;
   font-weight: 700;
   line-height: 1.2;

--- a/blocks/main-text/main-text.css
+++ b/blocks/main-text/main-text.css
@@ -1,5 +1,6 @@
 .main-text {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 20px;
   font-weight: 400;
   line-height: 1.2;

--- a/blocks/small-text/small-text.css
+++ b/blocks/small-text/small-text.css
@@ -1,5 +1,6 @@
 .small-text {
   font-family: 'Raleway', Arial, Helvetica, sans-serif;
+  font-feature-settings: 'pnum' on, 'lnum' on;
   font-size: 18px;
   font-weight: 500;
   line-height: 1.2;


### PR DESCRIPTION
Add `pnum` and `lnum` font features for all typography elements except `button-text`, because it was done before.